### PR TITLE
Scaffold from entity class instead of json file

### DIFF
--- a/CleanGenerator/CleanGenerator.csproj
+++ b/CleanGenerator/CleanGenerator.csproj
@@ -13,6 +13,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation" Version="11.4.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />

--- a/CleanGenerator/TemplateModel.cs
+++ b/CleanGenerator/TemplateModel.cs
@@ -12,6 +12,14 @@ public record TemplateModel
 
     public required string ApiBasePath { get; init; }
 
+    public TemplateModel CloneWithoutIdPropertyConfig()
+    {
+        return this with
+        {
+            PropertyConfigs = PropertyConfigs.Where(_ => _.Name != "Id").ToList()
+        };
+    }
+
     public static string? FirstCharToLowerCase(string? str)
     {
         if (!string.IsNullOrEmpty(str) && char.IsUpper(str[0]))

--- a/CleanGenerator/Templates/CreateCommand/CreateCommandTemplateCode.cs
+++ b/CleanGenerator/Templates/CreateCommand/CreateCommandTemplateCode.cs
@@ -6,6 +6,6 @@ public partial class CreateCommandTemplate
 
     public CreateCommandTemplate(TemplateModel model)
     {
-        _model = model;
+        _model = model.CloneWithoutIdPropertyConfig();
     }
 }

--- a/CleanGenerator/Templates/CreateCommand/CreateCommandValidatorTemplateCode.cs
+++ b/CleanGenerator/Templates/CreateCommand/CreateCommandValidatorTemplateCode.cs
@@ -6,6 +6,6 @@ public partial class CreateCommandValidatorTemplate
 
     public CreateCommandValidatorTemplate(TemplateModel model)
     {
-        _model = model;
+        _model = model.CloneWithoutIdPropertyConfig();
     }
 }

--- a/CleanGenerator/Templates/Dto/DtoTemplateCode.cs
+++ b/CleanGenerator/Templates/Dto/DtoTemplateCode.cs
@@ -6,6 +6,6 @@ public partial class DtoTemplate
 
     public DtoTemplate(TemplateModel model)
     {
-        _model = model;
+        _model = model.CloneWithoutIdPropertyConfig();
     }
 }

--- a/CleanGenerator/Templates/E2eTests/E2eTestsCode.cs
+++ b/CleanGenerator/Templates/E2eTests/E2eTestsCode.cs
@@ -6,6 +6,6 @@ public partial class E2eTestsTemplate
 
     public E2eTestsTemplate(TemplateModel model)
     {
-        _model = model;
+        _model = model.CloneWithoutIdPropertyConfig();
     }
 }

--- a/CleanGenerator/Templates/TestDtos/TestCreateDtoCode.cs
+++ b/CleanGenerator/Templates/TestDtos/TestCreateDtoCode.cs
@@ -6,6 +6,6 @@ public partial class TestCreateDtoTemplate
 
     public TestCreateDtoTemplate(TemplateModel model)
     {
-        _model = model;
+        _model = model.CloneWithoutIdPropertyConfig();
     }
 }

--- a/CleanGenerator/Templates/TestDtos/TestDtoCode.cs
+++ b/CleanGenerator/Templates/TestDtos/TestDtoCode.cs
@@ -6,6 +6,6 @@ public partial class TestDtoTemplate
 
     public TestDtoTemplate(TemplateModel model)
     {
-        _model = model;
+        _model = model.CloneWithoutIdPropertyConfig();
     }
 }

--- a/CleanGenerator/Templates/TestDtos/TestUpdateDtoCode.cs
+++ b/CleanGenerator/Templates/TestDtos/TestUpdateDtoCode.cs
@@ -6,6 +6,6 @@ public partial class TestUpdateDtoTemplate
 
     public TestUpdateDtoTemplate(TemplateModel model)
     {
-        _model = model;
+        _model = model.CloneWithoutIdPropertyConfig();
     }
 }

--- a/CleanGenerator/Templates/UpdateCommand/UpdateCommandTemplateCode.cs
+++ b/CleanGenerator/Templates/UpdateCommand/UpdateCommandTemplateCode.cs
@@ -6,6 +6,6 @@ public partial class UpdateCommandTemplate
 
     public UpdateCommandTemplate(TemplateModel model)
     {
-        _model = model;
+        _model = model.CloneWithoutIdPropertyConfig();
     }
 }

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ To build and install the tool globally on your local machine run this from ./Cle
 Then you can use it anywhere by running `cleangen ...`.
 
 ## TODO
-- [ ] Create output folder if it doesn't exist.
+
 - [ ] Support `DateTime` and `bool` property types.
-- [ ] Scaffold from entity instead of config.
 - [ ] FK relationships.
 - [ ] Allow specifying what properties appear on detail and summary dtos.
 - [ ] Allow skipping adding migration when adding entity.
@@ -32,6 +31,8 @@ Then you can use it anywhere by running `cleangen ...`.
 - [ ] Eliminate warnings when running dotnet pack.
 - [ ] Install dotnet ef tool locally.
 - [ ] Ensure that tool works cross platform, particularly path separators might need attention.
+- [x] Create output folder if it doesn't exist.
+- [x] Scaffold from entity instead of config.
 - [x] Scaffold e2e tests.
 - [x] Scaffold validation.
 - [x] Add delete command.

--- a/init-template/SourceSolution/Blahem.WebApi/Controllers/BlaitemController.cs
+++ b/init-template/SourceSolution/Blahem.WebApi/Controllers/BlaitemController.cs
@@ -1,4 +1,4 @@
-using Blahem.Application.Blaitem.Commands.Delete;
+using Blahem.Application.Blaitems.Commands.Delete;
 using Blahem.Application.Blaitems.Commands.Create;
 using Blahem.Application.Blaitems.Commands.Update;
 using Blahem.Application.Blaitems.Dtos;


### PR DESCRIPTION
Closes #8 

Replaces JSON file entity scaffolding with scaffolding based on the entity class itself.

Add command is now updated to take in the name of the entity e.g.

```ps1
 cleangen add --output "C:\workspace\CleanGeneratorOutput\test-output-2" --entity Blahem
```

This does not allow you to set further config against entity properties such as max length. 

Tested by generating a project and adding an entity via JSON config in the master branch version of CleanGen. Then generated a project and added an entity using this CS file approach. Compared the two projects with WinMerge. Only differences is the max length stuff as mentioned above.