### PR TITLE
Add NoDefaultExcludes to csproj so it copies .gitignore and .editorco…

### DIFF
--- a/CleanGenerator/CleanGenerator.csproj
+++ b/CleanGenerator/CleanGenerator.csproj
@@ -9,6 +9,7 @@
 		<Nullable>enable</Nullable>
 		<PackageOutputPath>./nupkg</PackageOutputPath>
 		<Version>0.0.1</Version>
+		<NoDefaultExcludes>true</NoDefaultExcludes>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
…nfig in output

Closes #18 

Discovered that the `.editorconfig` and `.gitignore` files get copied fine when you run this via Visual Studio. However, when you run it as an installed tool, then these files were not being copied across.

A quick Google search indicated that you need to set `NoDefaultExcludes` to `true` when packaging via nuget. `NoDefaultExcludes` was preventing hidden files (i.e. those starting with a `.`) from being packaged.